### PR TITLE
fix: Broken links (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://socialify.git.ci/EddieJaoudeCommunity/api/image?description=1&font=KoHo&logo=https%3A%2F%2Favatars.githubusercontent.com%2Fu%2F66388388%3Fs%3D200%26v%3D4&owner=1&pattern=Signal&theme=Light" alt="api" width="640" height="320" />
+  <img src="https://socialify.git.ci/EddieHubCommunity/api/image?description=1&font=KoHo&logo=https%3A%2F%2Favatars.githubusercontent.com%2Fu%2F66388388%3Fs%3D200%26v%3D4&owner=1&pattern=Signal&theme=Light" alt="api" width="640" height="320" />
 </p>
 
 [circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
@@ -7,11 +7,11 @@
 
 <p align="center">
 <img src="https://img.shields.io/badge/License-MIT-brightgreen" alt="License" />
-<img alt="GitHub issues" src="https://img.shields.io/github/issues/EddieJaoudeCommunity/api">
-<img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/EddieJaoudeCommunity/api">
+<img alt="GitHub issues" src="https://img.shields.io/github/issues/EddieHubCommunity/api">
+<img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/EddieHubCommunity/api">
 <a href="https://discord.gg/jZQs6Wu" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<img alt="GitHub forks" src="https://img.shields.io/github/forks/EddieJaoudeCommunity/api?style=social">
-<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/EddieJaoudeCommunity/api?style=social">
+<img alt="GitHub forks" src="https://img.shields.io/github/forks/EddieHubCommunity/api?style=social">
+<img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/EddieHubCommunity/api?style=social">
 </p>
 
 ## Description
@@ -21,7 +21,7 @@ An API to manage our community data
 ## Rules
 
 - Commits follow the standard [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/)
-- Branches should be named as `issue-<issue no>` (e.g. [NestJs](https://github.com/EddieJaoudeCommunity/api/issues/12) issue number is 12)
+- Branches should be named as `issue-<issue no>` (e.g. [NestJs](https://github.com/EddieHubCommunity/api/issues/12) issue number is 12)
 
 ## Installation
 


### PR DESCRIPTION
Closes #37 

### Description:
There are two problems with this issue:
1. `EddieJaoudeCommunity` is put in the URL instead of `EddieHubCommunity` as a GitHub Owner
2. There is something wrong with shields.io (Screenshot below)

<img width="1552" alt="Screen Shot 2021-04-12 at 20 24 25" src="https://user-images.githubusercontent.com/61970868/114428384-2d90d700-9bcd-11eb-8a90-f5ce74c2ca3d.png">
