### PR TITLE
Logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 APPROVED_TOKENS=abc,def
+DEBUG=false

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## Logging
+
+Logging can be turned on by settings an environmentvariable `DEBUG=true`
+If this variables is not true or undefiend no Logs will be made.
+
+When set to `true` the App will Log every incoming request.
+
 ## Running the app via Docker
 
 1. `docker run -p 3000:3000 -d ghcr.io/eddiehubcommunity/api:latest`
@@ -70,6 +77,5 @@ $ npm run test:cov
 ## License
 
 [MIT licensed](LICENSE).
-
 
 ## MADE WITH :heart: BY EDDIEHUBBERS :sparkles::sparkles:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DiscordModule } from './discord/discord.module';
@@ -6,6 +6,7 @@ import { StandupModule } from './standup/standup.module';
 import { GithubModule } from './github/github.module';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
+import { LoggerMiddleware } from './logger/logger.middleware';
 
 @Module({
   imports: [
@@ -20,4 +21,8 @@ import { AuthModule } from './auth/auth.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggerMiddleware).forRoutes('/');
+  }
+}

--- a/src/logger/logger.middleware.spec.ts
+++ b/src/logger/logger.middleware.spec.ts
@@ -1,0 +1,9 @@
+import { ConfigService } from '@nestjs/config';
+import { LoggerMiddleware } from './logger.middleware';
+
+describe('LoggerMiddleware', () => {
+  const config: ConfigService = new ConfigService();
+  it('should be defined', () => {
+    expect(new LoggerMiddleware(config)).toBeDefined();
+  });
+});

--- a/src/logger/logger.middleware.ts
+++ b/src/logger/logger.middleware.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  constructor(private readonly config: ConfigService) {}
+  private readonly logger = new Logger(LoggerMiddleware.name);
+  use(req: any, res: any, next: () => void) {
+    try {
+      if (JSON.parse(this.config.get('DEBUG'))) {
+        const { body, method, url } = req;
+
+        res.on('finish', () => {
+          const { statusCode } = res;
+          this.logger.log(
+            `${statusCode} | [${method}] ${url} - ${JSON.stringify(body)}`,
+          );
+        });
+        next();
+      }
+    } catch {
+      next();
+    }
+  }
+}

--- a/src/logger/logger.middleware.ts
+++ b/src/logger/logger.middleware.ts
@@ -19,8 +19,8 @@ export class LoggerMiddleware implements NestMiddleware {
             )}`,
           );
         });
-        next();
       }
+      next();
     } catch {
       next();
     }

--- a/src/logger/logger.middleware.ts
+++ b/src/logger/logger.middleware.ts
@@ -1,19 +1,22 @@
 import { Injectable, Logger, NestMiddleware } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
   constructor(private readonly config: ConfigService) {}
   private readonly logger = new Logger(LoggerMiddleware.name);
-  use(req: any, res: any, next: () => void) {
+  use(req: Request, res: Response, next: () => void) {
     try {
       if (JSON.parse(this.config.get('DEBUG'))) {
-        const { body, method, url } = req;
+        const { body, method, originalUrl } = req;
 
         res.on('finish', () => {
           const { statusCode } = res;
           this.logger.log(
-            `${statusCode} | [${method}] ${url} - ${JSON.stringify(body)}`,
+            `${statusCode} | [${method}] ${originalUrl} - ${JSON.stringify(
+              body,
+            )}`,
           );
         });
         next();


### PR DESCRIPTION
fixes #60 
Uses the build-in Nest-Logger.
In case we want to extend Logging we should use a external logging-package like `winston`.

Logging can be turned on by setting environmentvariable `DEBUG=true`.